### PR TITLE
ci: keep release-please on v* tags instead of component-prefixed ones

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,5 +6,7 @@
       "release-type": "node",
       "changelog-path": "Changelog.md"
     }
-  }
+  },
+  "include-component-in-tag": false,
+  "separate-pull-requests": false
 }


### PR DESCRIPTION
## Two problems from the first release-please run

**1. Tag format mismatch (fixed here).** Manifest mode derives a component from the package name and would tag releases `poe-api-manager-v2.1.0`. That does not match the existing `v2.0.0` tag, so release-please did not recognise the last release and recomputed the version from the whole history — it proposed **2.1.0** when the only commits since v2.0.0 are `ci:` ones, which should produce no release at all.

`include-component-in-tag: false` restores plain `v*` tags and makes the existing v2.0.0 the recognised baseline.

**2. Repository setting (needs a human).** The run failed with:

```
release-please failed: GitHub Actions is not permitted to create or approve pull requests.
```

That is **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"**, currently off. release-please cannot open its release PR without it. Only the repository owner can flip it.

`default_workflow_permissions` stays on `read` — every workflow here declares its own `permissions:` block, so nothing needs the broader write default.

## After merging

Once the setting is on, release-please opens a release PR whenever a `feat:` or `fix:` commit lands on main. Merging that PR publishes to npm and only then creates the tag and release.

There is also a stale `release-please--branches--main--components--poe-api-manager` branch left by the failed run; it is dead once this merges, since the branch name no longer carries the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014M2wrkyLWbv4qDXbPRBhp8