### PR TITLE
fix: stop the Merge plugin from stripping the release branch component

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,5 @@
       "component": "poe-api-manager"
     }
   },
-  "include-component-in-tag": false,
-  "separate-pull-requests": false
+  "include-component-in-tag": false
 }


### PR DESCRIPTION
Follow-up to #31. Pinning the component was necessary but not sufficient — the release branch was still created as `release-please--branches--main` with no component, so the readback comparison kept failing and #32 would have produced no release either.

The cause is `separate-pull-requests: false`, which I added in the tag-format fix. It enables the Merge plugin, and `plugins/merge.ts` builds the head ref as:

```ts
headRefName: this.headBranchName ?? BranchName.ofTargetBranch(targetBranch).toString()
```

dropping the component that `base.ts` would otherwise include. With a single package there is nothing to merge, so the plugin only does harm here.

Expected after merge: the release PR branch becomes `release-please--branches--main--components--poe-api-manager`, which matches the pinned component on readback. Tags stay plain `v*` because `getComponent()` honours `include-component-in-tag: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014M2wrkyLWbv4qDXbPRBhp8
