### PR TITLE
fix: stop each release from spawning a bogus next-version PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,23 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Split in two on purpose. release-please builds the next release PR in the
+  # same run that it creates a release -- and because the release is a draft,
+  # its tag does not exist yet, so the PR it builds looks past the version just
+  # released and proposes a bogus next one. Creating the release here and
+  # building the PR only after publish has undrafted it (see release-pr below)
+  # means the tag is always visible when the PR is built.
   release-please:
     runs-on: ubuntu-latest
     outputs:
       released: ${{ steps.release.outputs.release_created }}
       tag: ${{ steps.release.outputs.tag_name }}
     steps:
-      - name: 🔖 Release please
+      - name: 🔖 Create the GitHub release
         id: release
         uses: googleapis/release-please-action@v5
+        with:
+          skip-github-pull-request: true
 
   # Publishing lives in this workflow rather than a tag-triggered one because a
   # tag pushed by GITHUB_TOKEN does not trigger other workflows, so a separate
@@ -78,3 +86,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release-please.outputs.tag }}
+
+  # Runs once the tag exists, or straight after release-please when there was
+  # nothing to release. Skipped when publishing failed, so a broken release does
+  # not also spawn a release PR for the next version.
+  release-pr:
+    needs: [release-please, publish]
+    if: ${{ always() && needs.release-please.result == 'success' && needs.publish.result != 'failure' && needs.publish.result != 'cancelled' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: 🔖 Build the next release PR
+        uses: googleapis/release-please-action@v5
+        with:
+          skip-github-release: true


### PR DESCRIPTION
## Releasing 2.1.0 left a bogus 2.2.0 PR behind

Open PR #35 proposed 2.2.0, built from commits that were already part of 2.1.0. Merging it would have cut a version out of already-released work — and this would have recurred after **every** release, not just this one.

From the 2.1.0 run's log:

```
✔ Building releases                    ← creates the draft release for 2.1.0
✔ Building pull requests
❯ looking for tagName: v2.1.0
⚠ Expected 1 releases, only found 0    ← draft releases have no tag
✔ Considering: 53 commits              ← so it scanned back past 2.1.0
✔ updating from 2.1.0 to 2.2.0
```

## Cause

release-please creates releases and builds the next release PR in a single run. The draft release is deliberate — it is what keeps a tag and a visible release from existing unless npm accepted the package first. But a draft has no git tag, so the PR-building phase of that same run cannot see the version it just released and always looks one release too far back.

## Fix

Two invocations instead of one:

| Job | Does | Guard |
| --- | --- | --- |
| `release-please` | creates the draft release | `skip-github-pull-request: true` |
| `publish` | builds, tests, publishes to npm, undrafts (creating the tag) | only when a release was created |
| `release-pr` | builds the next release PR | `skip-github-release: true`, needs `publish` |

By the time `release-pr` runs, undrafting has created the tag, so the baseline is correct. It is skipped when publishing failed, so a broken release does not also open a release PR for the next version.

The draft-gating guarantee is unchanged: no tag and no visible release unless npm accepted the package.

Stale PR #35 and its branch are already closed and deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014M2wrkyLWbv4qDXbPRBhp8
